### PR TITLE
feat: Add github action to deploy docs to VPS

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,38 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.8.20
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8.20"
+
+      - name: Install MkDocs toolchain
+        run: |
+          pip install \
+            mkdocs==1.6.1 \
+            mkdocs-material==9.6.15 \
+            mkdocs-awesome-pages-plugin==2.9.2
+
+      - name: Build documentation
+        run: pdm mkdocs-build
+
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Deploy to VPS
+        env:
+          SSHPASS: ${{ secrets.SSH_PASSWORD }}
+        run: |
+          sshpass -e rsync -avz --delete ./site/ \
+            root@${{ secrets.SSH_HOST }}:/var/www/vhosts/simonwaiblinger.de/rustico.simonwaiblinger.de/httpdocs/


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automatically deploy the MkDocs documentation to a VPS. The workflow is triggered on pushes to the `main` branch.

The workflow performs the following steps:

- Checks out the code.
- Sets up Python 3.8.20.
- Installs the MkDocs toolchain, including mkdocs, mkdocs-material, and mkdocs-awesome-pages-plugin.
- Builds the documentation using `pdm mkdocs-build`.
- Installs sshpass.
- Deploys the documentation to the VPS using rsync over SSH. The SSH password is stored as a secret in GitHub.